### PR TITLE
Upgrade Project to .NET 10

### DIFF
--- a/src/NosCore.Analyzers/Analyzers/I18NPacketAnalyzer.cs
+++ b/src/NosCore.Analyzers/Analyzers/I18NPacketAnalyzer.cs
@@ -6,8 +6,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace NosCore.Analyzers.Analyzers
 {
@@ -66,7 +64,7 @@ namespace NosCore.Analyzers.Analyzers
                 var fields = enumType?.GetMembers().Where(m => m.Kind == SymbolKind.Field).OfType<IFieldSymbol>().ToList();
                 var field = fields?.FirstOrDefault(x => x.Name == enumValue?.Name.ToString()) ?? fields?.First() ?? throw new ArgumentException();
                 var attribute = field.GetAttributes().FirstOrDefault(x => x.AttributeClass?.Name == "Game18NArgumentsAttribute");
-                arguments.AddRange(attribute?.ConstructorArguments.First().Values.Where(x=>x.Value != null).Select(x => x.Value!.ToString()) ?? new List<string>());
+                arguments.AddRange(attribute?.ConstructorArguments.First().Values.Where(x=>x.Value != null).Select(x => x.Value!.ToString()).Where(x => x != null).Cast<string>() ?? new List<string>());
             }
 
             var error = false;

--- a/src/NosCore.Analyzers/NosCore.Analyzers.csproj
+++ b/src/NosCore.Analyzers/NosCore.Analyzers.csproj
@@ -28,8 +28,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
 		<PackageReference Update="NETStandard.Library" PrivateAssets="all" />
 	</ItemGroup>
 

--- a/src/NosCore.Analyzers/NosCore.Analyzers.csproj
+++ b/src/NosCore.Analyzers/NosCore.Analyzers.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
+		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<ApplicationIcon>favicon.ico</ApplicationIcon>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>NosCore</Authors>

--- a/src/NosCore.Analyzers/NosCore.Analyzers.csproj
+++ b/src/NosCore.Analyzers/NosCore.Analyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ApplicationIcon>favicon.ico</ApplicationIcon>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -27,8 +27,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.3.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
 		<PackageReference Update="NETStandard.Library" PrivateAssets="all" />
 	</ItemGroup>
 

--- a/test/NosCore.Analyzers.Tests/.runsettings
+++ b/test/NosCore.Analyzers.Tests/.runsettings
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <MSTest>
+    <Parallelize>
+      <Workers>0</Workers>
+      <Scope>MethodLevel</Scope>
+    </Parallelize>
+  </MSTest>
+</RunSettings>

--- a/test/NosCore.Analyzers.Tests/NosCore.Analyzers.Tests.csproj
+++ b/test/NosCore.Analyzers.Tests/NosCore.Analyzers.Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.MSTest" Version="1.1.2" />
     <PackageReference Include="NosCore.Packets" Version="16.0.0" />
   </ItemGroup>
 

--- a/test/NosCore.Analyzers.Tests/NosCore.Analyzers.Tests.csproj
+++ b/test/NosCore.Analyzers.Tests/NosCore.Analyzers.Tests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.1" />
-    <PackageReference Include="NosCore.Packets" Version="13.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.2" />
+    <PackageReference Include="NosCore.Packets" Version="16.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NosCore.Analyzers.Tests/NosCore.Analyzers.Tests.csproj
+++ b/test/NosCore.Analyzers.Tests/NosCore.Analyzers.Tests.csproj
@@ -12,9 +12,10 @@
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.MSTest" Version="1.1.2" />
     <PackageReference Include="NosCore.Packets" Version="16.0.0" />
   </ItemGroup>
 

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -7,7 +7,7 @@ namespace NosCore.Analyzers.Test
     public static partial class CSharpAnalyzerVerifier<TAnalyzer>
         where TAnalyzer : DiagnosticAnalyzer, new()
     {
-        public class Test : CSharpAnalyzerTest<TAnalyzer, MSTestVerifier>
+        public class Test : CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
         {
             public Test()
             {

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace NosCore.Analyzers.Test
 {

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -13,15 +13,15 @@ namespace NosCore.Analyzers.Test
     {
         /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic()"/>
         public static DiagnosticResult Diagnostic()
-            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic();
+            => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic();
 
         /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
         public static DiagnosticResult Diagnostic(string diagnosticId)
-            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(diagnosticId);
+            => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(diagnosticId);
 
         /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
-            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(descriptor);
+            => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(descriptor);
 
         /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
         public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace NosCore.Analyzers.Test
 {

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -9,7 +9,7 @@ namespace NosCore.Analyzers.Test
         where TAnalyzer : DiagnosticAnalyzer, new()
         where TCodeFix : CodeFixProvider, new()
     {
-        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, MSTestVerifier>
+        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
         {
             public Test()
             {

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -15,15 +15,15 @@ namespace NosCore.Analyzers.Test
     {
         /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
         public static DiagnosticResult Diagnostic()
-            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic();
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic();
 
         /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(string)"/>
         public static DiagnosticResult Diagnostic(string diagnosticId)
-            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(diagnosticId);
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(diagnosticId);
 
         /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
-            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(descriptor);
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(descriptor);
 
         /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
         public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -7,7 +7,7 @@ namespace NosCore.Analyzers.Test
     public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
         where TCodeRefactoring : CodeRefactoringProvider, new()
     {
-        public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, MSTestVerifier>
+        public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, DefaultVerifier>
         {
             public Test()
             {

--- a/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/test/NosCore.Analyzers.Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace NosCore.Analyzers.Test
 {


### PR DESCRIPTION
- Updated target framework from netstandard2.0 to net10.0 for main project
- Updated target framework from net8.0 to net10.0 for test project
- Updated Microsoft.CodeAnalysis packages from 4.3.1 to 4.14.0
- Updated Microsoft.NET.Test.Sdk from 17.4.0 to 18.0.1
- Updated MSTest packages from 2.2.10 to 4.0.2
- Updated CodeAnalysis.Testing packages from 1.1.1 to 1.1.2
- Updated NosCore.Packets from 13.0.0 to 16.0.0